### PR TITLE
Dismantle Mux expression / Ternary operator in dpdk

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -65,3 +65,7 @@ p4c_add_xfail_reason("dpdk"
   testdata/p4_16_samples/psa-dpdk-lpm-match-err2.p4
   )
 
+p4c_add_xfail_reason("dpdk"
+  "Non Type_Bits type bool for expression"
+  testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
+  )

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -53,6 +53,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new P4::TypeChecking(refMap, typeMap),
         // TBD: implement dpdk lowering passes instead of reusing bmv2's lowering pass.
         new BMV2::LowerExpressions(typeMap),
+        new SimplifyTernaryOperator(typeMap, refMap),
         new P4::RemoveComplexExpressions(refMap, typeMap,
                 new DPDK::ProcessControls(&structure.pipeline_controls)),
         new P4::ConstantFolding(refMap, typeMap, false),

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -931,6 +931,106 @@ const IR::Node* PrependPDotToActionArgs::preorder(IR::MethodCallExpression* mce)
             arguments);
 }
 
+const IR::Node* SimplifyTernaryOperator::preorder(IR::Mux* expression) {
+    // We always dismantle muxes for dpdk
+    auto type = typeMap->getType(getOriginal(), true);
+    visit(expression->e0);
+    auto tmp = createTemporary(type);
+    auto save = statements;
+    statements.clear();
+    visit(expression->e1);
+    (void) addAssignment(expression->srcInfo, tmp, expression->e1);
+    auto ifTrue = statements;
+
+    statements.clear();
+    visit(expression->e2);
+    auto path = addAssignment(expression->srcInfo, tmp, expression->e2);
+    auto ifFalse = statements;
+    statements = save;
+
+    auto ifStatement = new IR::IfStatement(
+        expression->e0, new IR::BlockStatement(ifTrue), new IR::BlockStatement(ifFalse));
+    statements.push_back(ifStatement);
+    typeMap->setType(path, type);
+    prune();
+    return path;
+}
+
+cstring SimplifyTernaryOperator::createTemporary(const IR::Type* type) {
+    type = type->getP4Type();
+    auto tmp = refMap->newName("tmp");
+    auto decl = new IR::Declaration_Variable(IR::ID(tmp, nullptr), type);
+    toInsert.push_back(decl);
+    return tmp;
+}
+
+const IR::Expression* SimplifyTernaryOperator::addAssignment(
+    Util::SourceInfo srcInfo,
+    cstring varName,
+    const IR::Expression* expression) {
+    const IR::PathExpression* left;
+    if (auto pe = expression->to<IR::PathExpression>())
+        left = new IR::PathExpression(IR::ID(varName, pe->path->name.originalName));
+    else
+        left = new IR::PathExpression(IR::ID(varName));
+    auto stat = new IR::AssignmentStatement(srcInfo, left, expression);
+    statements.push_back(stat);
+    auto result = left->clone();
+    return result;
+}
+
+const IR::Node* SimplifyTernaryOperator::postorder(IR::P4Action* action) {
+    if (toInsert.empty())
+        return action;
+    auto body = new IR::BlockStatement(action->body->srcInfo);
+    for (auto a : toInsert)
+        body->push_back(a);
+    for (auto s : action->body->components)
+        body->push_back(s);
+    action->body = body;
+    toInsert.clear();
+    return action;
+}
+
+
+const IR::Node* SimplifyTernaryOperator::postorder(IR::Function* function) {
+    if (toInsert.empty())
+        return function;
+    auto body = new IR::BlockStatement(function->body->srcInfo);
+    for (auto a : toInsert)
+        body->push_back(a);
+    for (auto s : function->body->components)
+        body->push_back(s);
+    function->body = body;
+    toInsert.clear();
+    return function;
+}
+
+const IR::Node* SimplifyTernaryOperator::postorder(IR::P4Parser* parser) {
+    if (toInsert.empty())
+        return parser;
+    parser->parserLocals.append(toInsert);
+    toInsert.clear();
+    return parser;
+}
+
+const IR::Node* SimplifyTernaryOperator::postorder(IR::P4Control* control) {
+    if (toInsert.empty())
+        return control;
+    control->controlLocals.append(toInsert);
+    toInsert.clear();
+    return control;
+}
+
+const IR::Node* SimplifyTernaryOperator::postorder(IR::AssignmentStatement* statement) {
+    if (statements.empty())
+        return statement;
+    statements.push_back(statement);
+    auto block = new IR::BlockStatement(statements);
+    statements.clear();
+    return block;
+}
+
 /* This function transforms the table so that all match keys come from the same struct.
    Mirror copies of match fields are created in metadata struct and table is updated to
    use the metadata fields.

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -312,6 +312,31 @@ class PrependPDotToActionArgs : public Transform {
     const IR::Node *preorder(IR::MethodCallExpression*) override;
 };
 
+// dpdk does not support ternary operator so we need to translate ternary operator
+// to corresponding if else statement
+// Taken from frontend pass DoSimplifyExpressions in sideEffects.h
+class SimplifyTernaryOperator : public Transform {
+    P4::TypeMap* typeMap;
+    P4::ReferenceMap *refMap;
+    IR::IndexedVector<IR::Declaration> toInsert;  // temporaries
+    IR::IndexedVector<IR::StatOrDecl> statements;
+
+    cstring createTemporary(const IR::Type* type);
+    const IR::Expression* addAssignment(Util::SourceInfo srcInfo, cstring varName,
+                                        const IR::Expression* expression);
+
+  public:
+    SimplifyTernaryOperator(P4::TypeMap* typeMap,
+                            P4::ReferenceMap *refMap)
+        : typeMap(typeMap), refMap(refMap) {}
+    const IR::Node* preorder(IR::Mux* expression) override;
+    const IR::Node* postorder(IR::P4Parser* parser) override;
+    const IR::Node* postorder(IR::Function* function) override;
+    const IR::Node* postorder(IR::P4Control* control) override;
+    const IR::Node* postorder(IR::P4Action* action) override;
+    const IR::Node* postorder(IR::AssignmentStatement* statement) override;
+};
+
 // For dpdk asm, there is not object-oriented. Therefore, we cannot define a
 // checksum in dpdk asm. And dpdk asm only provides ckadd(checksum add) and
 // cksub(checksum sub). So we need to define a explicit state for each checksum

--- a/testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
+++ b/testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
@@ -1,0 +1,220 @@
+/*
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    bit<1> rng_result1;
+    bit<16> min1;
+    bit<16> max1;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+    tcp_t tcp;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.tcp);
+        main_meta.rng_result1  = (bit<1>) ((main_meta.min1 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= main_meta.max1));
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+bit<1> dummy_func(inout headers_t hdr,   bit<16> min1,
+        bit<16> max1,inout main_metadata_t user_meta){
+    return  (bit<1>) ((min1 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= max1));
+}
+
+action do_range_checks_0 (inout headers_t hdr,inout main_metadata_t user_meta,
+        bit<16> min1,
+        bit<16> max1) {
+    user_meta.rng_result1  = dummy_func(hdr,min1, max1, user_meta );
+}
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp);
+    }
+
+    action do_range_checks_1 (
+        bit<16> min1,
+        bit<16> max1)
+    {
+        user_meta.rng_result1 =  (bit<1>) ((min1 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= max1));
+    }
+
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop", action_params = {32w0, 32w1234});
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+            do_range_checks_1;
+            do_range_checks_0(hdr,user_meta);
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        user_meta.rng_result1  = (bit<1>) ((100 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= 200));
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-mux-dismantle.p4
+++ b/testdata/p4_16_samples/pna-mux-dismantle.p4
@@ -1,0 +1,218 @@
+/*
+Copyright 2022 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    bit<1> rng_result1;
+    bit<1> val1;
+    bit<1> val2;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+    tcp_t tcp;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+bit<1> dummy_func(inout headers_t hdr,   bit<16> min1,
+        bit<16> max1,inout main_metadata_t user_meta){
+    return  (bit<1>) ((min1 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= max1));
+}
+
+action do_range_checks_0 (inout headers_t hdr,inout main_metadata_t user_meta,
+        bit<16> min1,
+        bit<16> max1) {
+    user_meta.rng_result1  = dummy_func(hdr,min1, max1, user_meta );
+}
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp);
+    }
+
+    action do_range_checks_1 (
+        bit<16> min1,
+        bit<16> max1)
+    {
+        user_meta.rng_result1 = ((min1 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= max1)) ? ((16w50 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= 16w100)) ? user_meta.val1 : user_meta.val2 : user_meta.val1;
+    }
+
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop", action_params = {32w0, 32w1234});
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+            do_range_checks_1;
+            do_range_checks_0(hdr,user_meta);
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        user_meta.rng_result1  = (bit<1>) ((100 <= hdr.tcp.srcPort) && (hdr.tcp.srcPort <= 200));
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4-error
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
@@ -1,0 +1,192 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> flags
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct do_range_checks_0_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct do_range_checks_1_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_pre_input_metadata_input_port
+	bit<16> pna_pre_input_metadata_parser_error
+	bit<32> pna_pre_input_metadata_direction
+	bit<3> pna_pre_input_metadata_pass
+	bit<8> pna_pre_input_metadata_loopedback
+	bit<8> pna_pre_output_metadata_decrypt
+	bit<32> pna_pre_output_metadata_said
+	bit<16> pna_pre_output_metadata_decrypt_start_offset
+	bit<32> pna_main_parser_input_metadata_direction
+	bit<3> pna_main_parser_input_metadata_pass
+	bit<8> pna_main_parser_input_metadata_loopedback
+	bit<32> pna_main_parser_input_metadata_input_port
+	bit<32> pna_main_input_metadata_direction
+	bit<3> pna_main_input_metadata_pass
+	bit<8> pna_main_input_metadata_loopedback
+	bit<64> pna_main_input_metadata_timestamp
+	bit<16> pna_main_input_metadata_parser_error
+	bit<8> pna_main_input_metadata_class_of_service
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> pna_main_output_metadata_class_of_service
+	bit<1> local_metadata_rng_result1
+	bit<1> local_metadata_val1
+	bit<1> local_metadata_val2
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_4
+	bit<1> MainControlT_tmp_0
+	bit<1> MainControlT_tmp_1
+	tcp_t MainControlT_hdr_3_tcp
+	bit<1> MainControlT_tmp
+	bit<1> MainControlT_tmp_2
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action do_range_checks_0 args instanceof do_range_checks_0_arg_t {
+	mov m.MainControlT_hdr_3_tcp h.tcp
+	jmpgt LABEL_FALSE_1 t.min1 m.MainControlT_hdr_3_tcp.srcPort
+	jmpgt LABEL_FALSE_1 m.MainControlT_hdr_3_tcp.srcPort t.max1
+	mov m.MainControlT_tmp 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.MainControlT_tmp 0x0
+	LABEL_END_1 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp
+	return
+}
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	learn next_hop 0x0
+	return
+}
+
+action do_range_checks_1 args instanceof do_range_checks_1_arg_t {
+	jmpgt LABEL_FALSE_2 t.min1 h.tcp.srcPort
+	jmpgt LABEL_FALSE_2 h.tcp.srcPort t.max1
+	jmpgt LABEL_FALSE_3 0x32 h.tcp.srcPort
+	jmpgt LABEL_FALSE_3 h.tcp.srcPort 0x64
+	mov m.MainControlT_tmp_1 m.local_metadata_val1
+	jmp LABEL_END_3
+	LABEL_FALSE_3 :	mov m.MainControlT_tmp_1 m.local_metadata_val2
+	LABEL_END_3 :	mov m.MainControlT_tmp_0 m.MainControlT_tmp_1
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	mov m.MainControlT_tmp_0 m.local_metadata_val1
+	LABEL_END_2 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_0
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp_3 0x0
+	mov m.MainControlT_tmp_4 0x4d2
+	learn next_hop m.MainControlT_tmp_3
+	return
+}
+
+learner ipv4_da {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 65536
+	timeout 120
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+		do_range_checks_1
+		do_range_checks_0
+	}
+	default_action add_on_miss_action2 args none 
+	size 65536
+	timeout 120
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpgt LABEL_FALSE 0x64 h.tcp.srcPort
+	jmpgt LABEL_FALSE h.tcp.srcPort 0xc8
+	mov m.MainControlT_tmp_2 0x1
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.MainControlT_tmp_2 0x0
+	LABEL_END :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_2
+	jmpnv LABEL_END_0 h.ipv4
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END_0 :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+


### PR DESCRIPTION
This patch changes
Expression like this 
z = condition ? x : y;
to
temp = y;
if (condition)
temp =  x;
z = temp;

