### PR TITLE
Improve error message for count() in dpdk

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -679,7 +679,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 auto args = a->expr->arguments;
                 if (args->size() < 1){
                     ::error(ErrorType::ERR_UNEXPECTED, "Expected atleast 1 arguments for %1%",
-                            a->object->getName());
+                            a->method->getName());
                 } else {
                     const IR::Expression *incr = nullptr;
                     auto index = args->at(0)->expression;
@@ -688,7 +688,9 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                         incr = args->at(1)->expression;
                     if (!incr && value > 0) {
                         ::error(ErrorType::ERR_UNEXPECTED,
-                                "Expected packet length argument for %1%", a->object->getName());
+                                "Expected packet length argument for %1% " \
+                                "method of indirect counter",
+                                a->method->getName());
                         return false;
                     }
                     if (value == 2) {


### PR DESCRIPTION
Error without Fix
../p4c/testdata/p4_16_samples/psa-example-counters-bmv2.p4(127): [--Werror=unexpected] error: Expected packet length argument for port_bytes_in
port_bytes_in;
^^^^^^^^^^^^^


After Fix


/home/kumarkam/workspace/p4-dev/build1/p4include/dpdk/psa.p4(536): [--Werror=unexpected] error: Expected packet length argument for count of indirect counter
void count(in S index, @optional in bit<32> increment);
^^^^^