### PR TITLE
Emit table config from const entries

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -104,6 +104,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new InspectDpdkProgram(refMap, typeMap, &structure),
         new CheckExternInvocation(refMap, typeMap, &structure),
         new TypeWidthValidator(),
+        new EmitDpdkTableConfig(refMap, typeMap),
         new DpdkArchLast(),
         new VisitFunctor([this, genContextJson] {
             // Serialize context json object into user specified file

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2640,7 +2640,7 @@ void EmitDpdkTableConfig::addRange(const IR::Expression* k, int keyWidth, P4::Ty
         endStr = startStr;
     }
     print(startStr,"/");
-    print(endStr,"");
+    print(endStr," ");
 }
 
 void EmitDpdkTableConfig::addOptional(const IR::Expression* k, int keyWidth,

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2448,12 +2448,24 @@ const IR::Node* ElimHeaderCopy::postorder(IR::Member* m) {
     return m;
 }
 
+cstring EmitDpdkTableConfig::getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap) {
+    auto path = ke->matchType->path;
+    auto mt = refMap->getDeclaration(path, true)->to<IR::Declaration_ID>();
+    BUG_CHECK(mt != nullptr, "%1%: could not find declaration", ke->matchType);
+    return mt->name.name;
+}
+
 int EmitDpdkTableConfig::getTypeWidth(const IR::Type* type,
                                       P4::TypeMap* typeMap) {
-    /* Treat error type as string */
-    if (type->is<IR::Type_Error>())
-        return 0;
     return typeMap->widthBits(type, type->getNode(), false);
+}
+
+void EmitDpdkTableConfig::print(cstring str, cstring sep) {
+    dpdkTableConfigFile<<str<<sep;
+}
+
+void EmitDpdkTableConfig::print(big_int str, cstring sep) {
+    dpdkTableConfigFile<<"0x"<<std::hex<<str<<sep;
 }
 
 big_int EmitDpdkTableConfig::convertSimpleKeyExpressionToBigInt(
@@ -2464,18 +2476,18 @@ big_int EmitDpdkTableConfig::convertSimpleKeyExpressionToBigInt(
         return static_cast<big_int>(k->to<IR::BoolLiteral>()->value
                                     ? 1 : 0);
     } else if (k->is<IR::Member>()) {  // handle SerEnum members
-            auto mem = k->to<IR::Member>();
-            auto se = mem->type->to<IR::Type_SerEnum>();
-            auto ei = P4::EnumInstance::resolve(mem, typeMap);
-            if (!ei) return -1;
-            if (auto sei = ei->to<P4::SerEnumInstance>()) {
-                auto type = sei->value->to<IR::Constant>();
-                auto w = se->type->width_bits();
-                BUG_CHECK(w == keyWidth, "SerEnum bitwidth mismatch");
-                return type->value;
-            }
-            ::error(ErrorType::ERR_INVALID, "%1% invalid Member key expression", k);
-            return -1;
+        auto mem = k->to<IR::Member>();
+        auto se = mem->type->to<IR::Type_SerEnum>();
+        auto ei = P4::EnumInstance::resolve(mem, typeMap);
+        if (!ei) return -1;
+        if (auto sei = ei->to<P4::SerEnumInstance>()) {
+            auto type = sei->value->to<IR::Constant>();
+            auto w = se->type->width_bits();
+            BUG_CHECK(w == keyWidth, "SerEnum bitwidth mismatch");
+            return type->value;
+        }
+        ::error(ErrorType::ERR_INVALID, "%1% invalid Member key expression", k);
+        return -1;
     } else if (k->is<IR::Cast>()) {
         return convertSimpleKeyExpressionToBigInt(k->to<IR::Cast>()->expr, keyWidth, typeMap);
     } else {
@@ -2492,53 +2504,172 @@ void EmitDpdkTableConfig::addAction(const IR::Expression* actionRef,
     auto decl = refMap->getDeclaration(method, true);
     auto actionDecl = decl->to<IR::P4Action>();
     auto actionName = actionDecl->controlPlaneName();
-    dpdkTableConfigFile<<actionName<<" ";
-    std::vector<cstring> paramNames;
-    std::vector<big_int> argVals;
-    auto parameter = actionDecl->parameters->parameters.at(0);
-    auto type = typeMap->getType(parameter);
-    if (auto actArg = type->to<IR::Type_Struct>()) {
-        for (auto f : actArg->fields)
-            paramNames.push_back(f->name);
-    }
-    for (auto args : *actionCall->arguments) {
-        for (auto arg : args->expression->to<IR::ListExpression>()->components) {
-            auto ei = P4::EnumInstance::resolve(arg, typeMap);
-            if (arg->is<IR::Constant>()) {
-                auto constant = arg->to<IR::Constant>();
-                auto argValue = constant->value;
-                argVals.push_back(argValue);
-            } else if (arg->is<IR::BoolLiteral>()) {
-                auto constant = arg->to<IR::BoolLiteral>();
-                auto argValue = static_cast<big_int>(constant->value ? 1 : 0);
-                argVals.push_back(argValue);
-            } else if (ei != nullptr && ei->is<P4::SerEnumInstance>()) {
-                auto sei = ei->to<P4::SerEnumInstance>();
-                auto argValue = sei->value->to<IR::Constant>();
-                argVals.push_back(argValue->value);
-            } else {
-                ::error(ErrorType::ERR_UNSUPPORTED,
-                        "%1% unsupported argument expression", arg);
-                continue;
+    print(actionName, " ");
+    if (actionDecl->parameters->parameters.size() == 1) {
+        std::vector<cstring> paramNames;
+        std::vector<big_int> argVals;
+        auto parameter = actionDecl->parameters->parameters.at(0);
+        auto type = typeMap->getType(parameter);
+        if (auto actArg = type->to<IR::Type_Struct>()) {
+            for (auto f : actArg->fields)
+                paramNames.push_back(f->name);
+        }
+        for (auto args : *actionCall->arguments) {
+            for (auto arg : args->expression->to<IR::ListExpression>()->components) {
+                auto ei = P4::EnumInstance::resolve(arg, typeMap);
+                if (arg->is<IR::Constant>()) {
+                    auto constant = arg->to<IR::Constant>();
+                    auto argValue = constant->value;
+                    argVals.push_back(argValue);
+                } else if (arg->is<IR::BoolLiteral>()) {
+                    auto constant = arg->to<IR::BoolLiteral>();
+                    auto argValue = static_cast<big_int>(constant->value ? 1 : 0);
+                    argVals.push_back(argValue);
+                } else if (ei != nullptr && ei->is<P4::SerEnumInstance>()) {
+                    auto sei = ei->to<P4::SerEnumInstance>();
+                    auto argValue = sei->value->to<IR::Constant>();
+                    argVals.push_back(argValue->value);
+                } else {
+                    ::error(ErrorType::ERR_UNSUPPORTED,
+                            "%1% unsupported argument expression", arg);
+                    continue;
+                }
             }
         }
-    }
 
-    for (size_t i = 0; i < argVals.size(); i++) {
-        dpdkTableConfigFile<<paramNames[i] << " "<< argVals[i]<<" ";
+        for (size_t i = 0; i < argVals.size(); i++) {
+            print(paramNames[i], " ");
+            print(argVals[i]);
+        }
     }
+}
+
+void EmitDpdkTableConfig::addExact(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap) {
+    auto value = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+    print(value, " ");
+}
+
+void EmitDpdkTableConfig::addLpm(const IR::Expression* k,
+            int keyWidth, P4::TypeMap *typeMap) {
+    if (k->is<IR::DefaultExpression>())  // don't care, skip in P4Runtime message
+        return;
+    big_int valueStr;
+    big_int mask;
+    if (k->is<IR::Mask>()) {
+        auto km = k->to<IR::Mask>();
+        auto value = convertSimpleKeyExpressionToBigInt(km->left, keyWidth, typeMap);
+        auto trailing_zeros = [keyWidth](const big_int& n) -> int {
+            return (n == 0) ? keyWidth : boost::multiprecision::lsb(n); };
+        auto count_ones = [](const big_int& n) -> int {
+            return bitcount(n); };
+        mask = km->right->to<IR::Constant>()->value;
+        auto len = trailing_zeros(mask);
+        if (len + count_ones(mask) != keyWidth) {  // any remaining 0s in the prefix?
+            ::error(ErrorType::ERR_INVALID, "%1% invalid mask for LPM key", k);
+            return;
+        }
+        if ((value & mask) != value) {
+            ::warning(ErrorType::WARN_MISMATCH,
+                        "P4Runtime requires that LPM matches have masked-off bits set to 0, "
+                        "updating value %1% to conform to the P4Runtime specification", km->left);
+            value &= mask;
+        }
+        valueStr = value;
+    } else {
+        valueStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+    }
+    print(valueStr,"/");
+    print(mask," ");
+}
+
+void EmitDpdkTableConfig::addTernary(const IR::Expression* k, int keyWidth,
+                P4::TypeMap* typeMap) {
+    if (k->is<IR::DefaultExpression>())  // don't care, skip in P4Runtime message
+        return;
+    big_int valueStr;
+    big_int maskStr;
+    if (k->is<IR::Mask>()) {
+        auto km = k->to<IR::Mask>();
+        auto value = convertSimpleKeyExpressionToBigInt(km->left, keyWidth, typeMap);
+        auto mask = convertSimpleKeyExpressionToBigInt(km->right, keyWidth, typeMap);
+        if ((value & mask) != value) {
+            ::warning(ErrorType::WARN_MISMATCH,
+                        "P4Runtime requires that Ternary matches have masked-off bits set to 0, "
+                        "updating value %1% to conform to the P4Runtime specification", km->left);
+            value &= mask;
+        }
+        valueStr = value;
+        maskStr = mask;
+    } else {
+        valueStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        maskStr = Util::mask(keyWidth);
+    }
+    print(valueStr, "/");
+    print(maskStr, " ");
+}
+
+void EmitDpdkTableConfig::addRange(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap) {
+    if (k->is<IR::DefaultExpression>())  // don't care, skip in P4Runtime message
+        return;
+    big_int startStr;
+    big_int endStr;
+    if (k->is<IR::Range>()) {
+        auto kr = k->to<IR::Range>();
+        auto start = convertSimpleKeyExpressionToBigInt(kr->left, keyWidth, typeMap);
+        auto end = convertSimpleKeyExpressionToBigInt(kr->right, keyWidth, typeMap);
+        // Error on invalid range values
+        big_int maxValue = (big_int(1) << keyWidth) - 1;
+        // NOTE: If end value is > max allowed for keyWidth, value gets
+        // wrapped around. A warning is issued in this case by the frontend
+        // earlier.
+        // For e.g. 16 bit key has a max value of 65535, Range of (1..65536)
+        // will be converted to (1..0) and will fail below check.
+        if (start > end)
+            ::error(ErrorType::ERR_INVALID, "%s Invalid range for table entry", kr->srcInfo);
+        startStr = start;
+        endStr = end;
+    } else {
+        startStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        endStr = startStr;
+    }
+    print(startStr,"/");
+    print(endStr,"");
+}
+
+void EmitDpdkTableConfig::addOptional(const IR::Expression* k, int keyWidth,
+                    P4::TypeMap* typeMap) {
+    if (k->is<IR::DefaultExpression>())  // don't care, skip in P4Runtime message
+        return;
+    auto value = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+    print(value," ");
 }
 
 void EmitDpdkTableConfig::addMatchKey(const IR::P4Table* table,
                      const IR::ListExpression* keyset,
                      P4::TypeMap* typeMap) {
-        int keyIndex = 0;
-        for (auto k : keyset->components) {
+    int keyIndex = 0;
+    for (auto k : keyset->components) {
             auto tableKey = table->getKey()->keyElements.at(keyIndex++);
             auto keyWidth = getTypeWidth(tableKey->expression->type, typeMap);
-            auto keyValue = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
-            dpdkTableConfigFile<<keyValue<<" ";
-        }
+            auto matchType = getKeyMatchType(tableKey, refMap);
+            if (matchType == P4::P4CoreLibrary::instance.exactMatch.name) {
+              addExact(k, keyWidth, typeMap);
+            } else if (matchType == P4::P4CoreLibrary::instance.lpmMatch.name) {
+              addLpm(k, keyWidth, typeMap);
+            } else if (matchType == P4::P4CoreLibrary::instance.ternaryMatch.name) {
+              addTernary(k, keyWidth, typeMap);
+            } else if (matchType == P4V1::V1Model::instance.rangeMatchType.name) {
+              addRange(k, keyWidth, typeMap);
+            } else if (matchType == P4V1::V1Model::instance.optionalMatchType.name) {
+              addOptional(k, keyWidth, typeMap);
+            } else {
+                if (!k->is<IR::DefaultExpression>())
+                    ::error(ErrorType::ERR_UNSUPPORTED,
+                         "%1%: match type not supported by P4Runtime serializer", matchType);
+                continue;
+            }
+    }
 }
 
 void EmitDpdkTableConfig::postorder(const IR::P4Table* table) {
@@ -2546,11 +2677,11 @@ void EmitDpdkTableConfig::postorder(const IR::P4Table* table) {
     if (entriesList == nullptr) return;
     dpdkTableConfigFile.open(table->externalName()+".txt");
     for (auto e : entriesList->entries) {
-        dpdkTableConfigFile<<"match ";
+        print("match"," ");
         addMatchKey(table, e->getKeys(), typeMap);
-        dpdkTableConfigFile<<"action ";
+        print("action"," ");
         addAction(e->getAction(), refMap, typeMap);
-        dpdkTableConfigFile<<"\n";
+        print("", "\n");
     }
     dpdkTableConfigFile.close();
 }

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -16,6 +16,7 @@ limitations under the License.
 
 #ifndef BACKENDS_DPDK_DPDKARCH_H_
 #define BACKENDS_DPDK_DPDKARCH_H_
+#include <fstream>
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/evaluator/evaluator.h"
@@ -26,6 +27,8 @@ limitations under the License.
 #include "lib/ordered_map.h"
 #include "dpdkProgramStructure.h"
 #include "constants.h"
+#include "lib/gmputil.h"
+#include "frontends/p4/enumInstance.h"
 
 namespace DPDK {
 
@@ -985,6 +988,26 @@ class ElimHeaderCopy : public Transform {
     const IR::Node* preorder(IR::AssignmentStatement* as) override;
     const IR::Node* preorder(IR::MethodCallStatement *mcs) override;
     const IR::Node* postorder(IR::Member* m) override;
+};
+
+class EmitDpdkTableConfig : public Inspector {
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
+    std::ofstream dpdkTableConfigFile;
+
+    void addMatchKey(const IR::P4Table* table,
+                     const IR::ListExpression* keyset,
+                     P4::TypeMap* typeMap);
+    void addAction(const IR::Expression* actionRef,
+                   P4::ReferenceMap* refMap,
+                   P4::TypeMap* typeMap);
+    int getTypeWidth(const IR::Type* type, P4::TypeMap* typeMap);
+    big_int convertSimpleKeyExpressionToBigInt(
+        const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+ public:
+    EmitDpdkTableConfig(P4::ReferenceMap* refMap,
+                        P4::TypeMap *typeMap) : refMap(refMap), typeMap(typeMap) {}
+    void postorder(const IR::P4Table* table) override;
 };
 
 class DpdkArchFirst : public PassManager {

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -29,6 +29,9 @@ limitations under the License.
 #include "constants.h"
 #include "lib/gmputil.h"
 #include "frontends/p4/enumInstance.h"
+#include "frontends/p4/coreLibrary.h"
+#include "frontends/p4/fromv1.0/v1model.h"
+
 
 namespace DPDK {
 
@@ -995,6 +998,16 @@ class EmitDpdkTableConfig : public Inspector {
     P4::TypeMap* typeMap;
     std::ofstream dpdkTableConfigFile;
 
+    void addExact(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addLpm(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addTernary(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addRange(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addOptional(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
     void addMatchKey(const IR::P4Table* table,
                      const IR::ListExpression* keyset,
                      P4::TypeMap* typeMap);
@@ -1002,8 +1015,12 @@ class EmitDpdkTableConfig : public Inspector {
                    P4::ReferenceMap* refMap,
                    P4::TypeMap* typeMap);
     int getTypeWidth(const IR::Type* type, P4::TypeMap* typeMap);
+    cstring getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap);
     big_int convertSimpleKeyExpressionToBigInt(
         const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void print(cstring str, cstring sep="");
+    void print(big_int, cstring sep="");
+
  public:
     EmitDpdkTableConfig(P4::ReferenceMap* refMap,
                         P4::TypeMap *typeMap) : refMap(refMap), typeMap(typeMap) {}

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -1019,6 +1019,8 @@ class EmitDpdkTableConfig : public Inspector {
     cstring getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap);
     big_int convertSimpleKeyExpressionToBigInt(
         const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    bool tableNeedsPriority(const IR::P4Table* table, P4::ReferenceMap* refMap);
+    bool isAllKeysDefaultExpression(const IR::ListExpression* keyset);
     void print(cstring str, cstring sep="");
     void print(big_int, cstring sep="");
 

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -30,8 +30,6 @@ limitations under the License.
 #include "lib/gmputil.h"
 #include "frontends/p4/enumInstance.h"
 #include "frontends/p4/coreLibrary.h"
-#include "frontends/p4/fromv1.0/v1model.h"
-
 
 namespace DPDK {
 
@@ -993,6 +991,9 @@ class ElimHeaderCopy : public Transform {
     const IR::Node* postorder(IR::Member* m) override;
 };
 
+// This Pass emits Table config consumed by dpdk target in a text file if
+// const entries are present in p4 program.
+// Most of the code taken from control-plane/p4RuntimeSerializer.h/.cpp
 class EmitDpdkTableConfig : public Inspector {
     P4::ReferenceMap* refMap;
     P4::TypeMap* typeMap;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
@@ -1,0 +1,171 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute(bit<48> x) {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+        const entries = {
+            (true,48w1,48w2) : execute(48w1);
+            (true,48w1,48w2) : execute(48w1);
+            (true,48w3,48w3) : execute(48w1);
+            }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
@@ -46,6 +46,10 @@ struct empty_metadata_t {
 
 struct metadata {
      bit<16> data;
+     bit<48> key1;
+     bit<48> key2;
+     bit<48> key3;
+     bit<48> key4;
 }
 
 struct headers {
@@ -96,16 +100,37 @@ control ingress(inout headers hdr,
             hdr.ethernet.isValid(): exact;
             hdr.ethernet.dstAddr : exact;
             hdr.ethernet.srcAddr : exact;
+            user_meta.key1 : ternary;
+            user_meta.key2 : range;
+            user_meta.key4: optional;
+
         }
+
         actions = { NoAction; execute; }
         const entries = {
-            (true,48w1,48w2) : execute(48w1);
-            (true,48w1,48w2) : execute(48w1);
-            (true,48w3,48w3) : execute(48w1);
+            (true,48w1,48w2,48w2&&&48w3, 48w2 .. 48w4, 48w10) : execute(48w1);
+            (true,48w1,48w2,48w2&&&48w3, 48w2 .. 48w5, 48w10)  : execute(48w1);
+            (true,48w3,48w3,48w2&&&48w3, 48w2 .. 48w6, 48w10) : execute(48w1);
+            }
+    }
+    table tbl1 {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+            user_meta.key3: lpm;
+        }
+
+        actions = { NoAction; execute; }
+        const entries = {
+            (true,48w1,48w2, 48w10) : execute(48w1);
+            (true,48w1,48w2, 48w11)  : execute(48w1);
+            (true,48w3,48w3, 48w12) : execute(48w1);
             }
     }
     apply {
             tbl.apply();
+            tbl1.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-first.p4
@@ -1,0 +1,134 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute(bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        const entries = {
+                        (true, 48w1, 48w2) : execute(48w1);
+                        (true, 48w1, 48w2) : execute(48w1);
+                        (true, 48w3, 48w3) : execute(48w1);
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
@@ -1,0 +1,136 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        const entries = {
+                        (true, 48w1, 48w2) : execute_1(48w1);
+                        (true, 48w1, 48w2) : execute_1(48w1);
+                        (true, 48w3, 48w3) : execute_1(48w1);
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
@@ -43,6 +43,10 @@ struct empty_metadata_t {
 
 struct metadata {
     bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
 }
 
 struct headers {
@@ -76,7 +80,12 @@ parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
     @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.execute") action execute_2(@name("x") bit<48> x_1) {
         user_meta.data = 16w1;
     }
     @name("ingress.tbl") table tbl_0 {
@@ -84,20 +93,42 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
             hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
             hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
             hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key1        : ternary @name("user_meta.key1") ;
+            user_meta.key2        : range @name("user_meta.key2") ;
+            user_meta.key4        : optional @name("user_meta.key4") ;
         }
         actions = {
             NoAction_1();
             execute_1();
         }
         const entries = {
-                        (true, 48w1, 48w2) : execute_1(48w1);
-                        (true, 48w1, 48w2) : execute_1(48w1);
-                        (true, 48w3, 48w3) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute_1(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute_1(48w1);
         }
         default_action = NoAction_1();
     }
+    @name("ingress.tbl1") table tbl1_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key3        : lpm @name("user_meta.key3") ;
+        }
+        actions = {
+            NoAction_2();
+            execute_2();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute_2(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute_2(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute_2(48w1);
+        }
+        default_action = NoAction_2();
+    }
     apply {
         tbl_0.apply();
+        tbl1_0.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
@@ -1,0 +1,154 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        const entries = {
+                        (true, 48w1, 48w2) : execute_1(48w1);
+                        (true, 48w1, 48w2) : execute_1(48w1);
+                        (true, 48w3, 48w3) : execute_1(48w1);
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconst_ent142() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconst_ent142 {
+        actions = {
+            psadpdktablekeyconst_ent142();
+        }
+        const default_action = psadpdktablekeyconst_ent142();
+    }
+    apply {
+        tbl_psadpdktablekeyconst_ent142.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconst_ent157() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconst_ent157 {
+        actions = {
+            psadpdktablekeyconst_ent157();
+        }
+        const default_action = psadpdktablekeyconst_ent157();
+    }
+    apply {
+        tbl_psadpdktablekeyconst_ent157.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
@@ -43,6 +43,10 @@ struct empty_metadata_t {
 
 struct metadata {
     bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
 }
 
 struct headers {
@@ -76,7 +80,12 @@ parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_
 control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
     @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.execute") action execute_2(@name("x") bit<48> x_1) {
         user_meta.data = 16w1;
     }
     @name("ingress.tbl") table tbl_0 {
@@ -84,20 +93,42 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
             hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
             hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
             hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key1        : ternary @name("user_meta.key1") ;
+            user_meta.key2        : range @name("user_meta.key2") ;
+            user_meta.key4        : optional @name("user_meta.key4") ;
         }
         actions = {
             NoAction_1();
             execute_1();
         }
         const entries = {
-                        (true, 48w1, 48w2) : execute_1(48w1);
-                        (true, 48w1, 48w2) : execute_1(48w1);
-                        (true, 48w3, 48w3) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute_1(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute_1(48w1);
         }
         default_action = NoAction_1();
     }
+    @name("ingress.tbl1") table tbl1_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key3        : lpm @name("user_meta.key3") ;
+        }
+        actions = {
+            NoAction_2();
+            execute_2();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute_2(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute_2(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute_2(48w1);
+        }
+        default_action = NoAction_2();
+    }
     apply {
         tbl_0.apply();
+        tbl1_0.apply();
     }
 }
 
@@ -113,36 +144,36 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 }
 
 control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
-    @hidden action psadpdktablekeyconst_ent142() {
+    @hidden action psadpdktablekeyconst_ent167() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
         packet.emit<tcp_t>(hdr.tcp);
     }
-    @hidden table tbl_psadpdktablekeyconst_ent142 {
+    @hidden table tbl_psadpdktablekeyconst_ent167 {
         actions = {
-            psadpdktablekeyconst_ent142();
+            psadpdktablekeyconst_ent167();
         }
-        const default_action = psadpdktablekeyconst_ent142();
+        const default_action = psadpdktablekeyconst_ent167();
     }
     apply {
-        tbl_psadpdktablekeyconst_ent142.apply();
+        tbl_psadpdktablekeyconst_ent167.apply();
     }
 }
 
 control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
-    @hidden action psadpdktablekeyconst_ent157() {
+    @hidden action psadpdktablekeyconst_ent182() {
         packet.emit<ethernet_t>(hdr.ethernet);
         packet.emit<ipv4_t>(hdr.ipv4);
         packet.emit<tcp_t>(hdr.tcp);
     }
-    @hidden table tbl_psadpdktablekeyconst_ent157 {
+    @hidden table tbl_psadpdktablekeyconst_ent182 {
         actions = {
-            psadpdktablekeyconst_ent157();
+            psadpdktablekeyconst_ent182();
         }
-        const default_action = psadpdktablekeyconst_ent157();
+        const default_action = psadpdktablekeyconst_ent182();
     }
     apply {
-        tbl_psadpdktablekeyconst_ent157.apply();
+        tbl_psadpdktablekeyconst_ent182.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
@@ -1,0 +1,133 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute(bit<48> x) {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr  : exact;
+            hdr.ethernet.srcAddr  : exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+        const entries = {
+                        (true, 48w1, 48w2) : execute(48w1);
+                        (true, 48w1, 48w2) : execute(48w1);
+                        (true, 48w3, 48w3) : execute(48w1);
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
@@ -43,6 +43,10 @@ struct empty_metadata_t {
 
 struct metadata {
     bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
 }
 
 struct headers {
@@ -82,19 +86,40 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
             hdr.ethernet.isValid(): exact;
             hdr.ethernet.dstAddr  : exact;
             hdr.ethernet.srcAddr  : exact;
+            user_meta.key1        : ternary;
+            user_meta.key2        : range;
+            user_meta.key4        : optional;
         }
         actions = {
             NoAction;
             execute;
         }
         const entries = {
-                        (true, 48w1, 48w2) : execute(48w1);
-                        (true, 48w1, 48w2) : execute(48w1);
-                        (true, 48w3, 48w3) : execute(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute(48w1);
+        }
+    }
+    table tbl1 {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr  : exact;
+            hdr.ethernet.srcAddr  : exact;
+            user_meta.key3        : lpm;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute(48w1);
         }
     }
     apply {
         tbl.apply();
+        tbl1.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
@@ -1,4 +1,5 @@
-psa-dpdk-table-key-const_ent.p4(91): [--Wwarn=unused] warning: 'x' is unused
+psa-dpdk-table-key-const_ent.p4(95): [--Wwarn=unused] warning: 'x' is unused
     action execute(bit<48> x) {
                            ^
 [--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl1. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
@@ -1,0 +1,4 @@
+psa-dpdk-table-key-const_ent.p4(91): [--Wwarn=unused] warning: 'x' is unused
+    action execute(bit<48> x) {
+                           ^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
@@ -1,0 +1,3 @@
+psa-dpdk-table-key-const_ent.p4(91): [--Wwarn=unused] warning: 'x' is unused
+    action execute(bit<48> x) {
+                           ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
@@ -1,3 +1,3 @@
-psa-dpdk-table-key-const_ent.p4(91): [--Wwarn=unused] warning: 'x' is unused
+psa-dpdk-table-key-const_ent.p4(95): [--Wwarn=unused] warning: 'x' is unused
     action execute(bit<48> x) {
                            ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
@@ -1,0 +1,85 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "x",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope", "ConstTable"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
@@ -45,6 +45,144 @@
             "type" : "bytes",
             "width" : 48
           }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.key1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Ternary",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "user_meta.key2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Range",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 6,
+          "name" : "user_meta.key4",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Optional",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 65537,
+          "name" : "$MATCH_PRIORITY",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "x",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope", "ConstTable"]
+    },
+    {
+      "name" : "ip.ingress.tbl1",
+      "id" : 33873526,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.key3",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "LPM",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
         }
       ],
       "action_specs" : [

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
@@ -1,0 +1,105 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
@@ -21,6 +21,26 @@ updates {
           value: "\000\000\000\000\000\002"
         }
       }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\004"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
       action {
         action {
           action_id: 29480552
@@ -30,6 +50,7 @@ updates {
           }
         }
       }
+      priority: 3
     }
   }
 }
@@ -56,6 +77,26 @@ updates {
           value: "\000\000\000\000\000\002"
         }
       }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\005"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
       action {
         action {
           action_id: 29480552
@@ -65,6 +106,7 @@ updates {
           }
         }
       }
+      priority: 2
     }
   }
 }
@@ -89,6 +131,153 @@ updates {
         field_id: 3
         exact {
           value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\006"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\n"
+          prefix_len: 48
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\013"
+          prefix_len: 48
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\014"
+          prefix_len: 48
         }
       }
       action {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
@@ -1,0 +1,58 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ethernet.dstAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 48
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
@@ -25,6 +25,63 @@ tables {
     bitwidth: 48
     match_type: EXACT
   }
+  match_fields {
+    id: 4
+    name: "user_meta.key1"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 5
+    name: "user_meta.key2"
+    bitwidth: 48
+    match_type: RANGE
+  }
+  match_fields {
+    id: 6
+    name: "user_meta.key4"
+    bitwidth: 48
+    match_type: OPTIONAL
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+  is_const_table: true
+}
+tables {
+  preamble {
+    id: 33873526
+    name: "ingress.tbl1"
+    alias: "tbl1"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ethernet.dstAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 4
+    name: "user_meta.key3"
+    bitwidth: 48
+    match_type: LPM
+  }
   action_refs {
     id: 21257015
   }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.spec
@@ -1,0 +1,129 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<48> x
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<8> ingress_tbl_ethernet_isValid
+	bit<48> ingress_tbl_ethernet_dstAddr
+	bit<48> ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.ingress_tbl_ethernet_isValid exact
+		m.ingress_tbl_ethernet_dstAddr exact
+		m.ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_ethernet_isValid 1
+	jmpv LABEL_END h.ethernet
+	mov m.ingress_tbl_ethernet_isValid 0
+	LABEL_END :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION
This PR emits new table config in txt format from const entries present in p4 program to be consumed by dpdk target.

i.e.

match 0x2/0x2 action MainControlImpl.tcp_syn_packet 
match 0x1/0x1 action MainControlImpl.tcp_fin_or_rst_packet 
match 0x4/0x4 action MainControlImpl.tcp_fin_or_rst_packet 

for p4 const entries:
const bit<8> TCP_RST_MASK = 0x04;
const bit<8> TCP_SYN_MASK = 0x02;
const bit<8> TCP_FIN_MASK = 0x01;

 const entries = {
            TCP_SYN_MASK &&& TCP_SYN_MASK: tcp_syn_packet;
            TCP_FIN_MASK &&& TCP_FIN_MASK: tcp_fin_or_rst_packet;
            TCP_RST_MASK &&& TCP_RST_MASK: tcp_fin_or_rst_packet;
        }
