### PR TITLE
Emit P4Info, Context, Entries and Bfrt as MEV

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -48,7 +48,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock* tlb) {
 
     std::set<const IR::P4Table*> invokedInKey;
     auto convertToDpdk = new ConvertToDpdkProgram(refMap, typeMap, &structure, options);
-    auto genContextJson = new DpdkContextGenerator(refMap, &structure, options);
+    auto genContextJson = new DpdkContextGenerator(refMap, typeMap, &structure, options);
 
     PassManager simplify = {
         new DpdkArchFirst(),

--- a/backends/dpdk/control-plane/bfruntime_ext.h
+++ b/backends/dpdk/control-plane/bfruntime_ext.h
@@ -71,7 +71,8 @@ class BFRuntimeSchemaGenerator : public BFRuntimeGenerator {
                           Util::JsonObject* tableJson) const override;
     void addMatchActionData(const p4configv1::Table& table, Util::JsonObject* tableJson,
                             Util::JsonArray* dataJson, P4Id maxActionParamId) const;
-
+    static Util::JsonObject* makeTypeInt(cstring type);
+    void addMatchValueLookupTables(Util::JsonArray* tablesJson) const;
     boost::optional<bool> actProfHasSelector(P4Id actProfId) const override;
 
     static boost::optional<ActionProf> fromDPDKActionProfile(

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -678,6 +678,12 @@ class CollectExternDeclaration : public Inspector {
                     ::error(ErrorType::ERR_EXPECTED,
                             "%1%: expected size and optionally init_val as arguments", d);
                 }
+            } else if (externTypeName == "MatchValueLookupTable") {
+                if (d->arguments->size() != 1 && d->arguments->size() != 2 &&
+                    d->arguments->size() != 3) {
+                    ::error(ErrorType::ERR_EXPECTED,
+                            "%1%: requires one or two or three arguments arguments", d);
+                }
             } else {
                 // unsupported extern type
                 return false;

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -156,6 +156,8 @@ void DpdkContextGenerator::CollectTablesAndSetAttributes() {
             }
             externAttrMap.emplace(ed->name.name, externAttr);
             externs.push_back(ed);
+        } else if (externTypeName == "MatchValueLookupTable") {
+            mvlTables.push_back(ed);
         }
     }
 
@@ -518,6 +520,217 @@ void DpdkContextGenerator::addExternInfo(Util::JsonArray* externsJson) {
     }
 }
 
+void DpdkContextGenerator::UpdateMatchKeys(P4MatchLookupTableInfo* emvlut, const IR::Type* type,
+                                           cstring instanceName) {
+    auto key = new MatchKeyField();
+    if (type->is<IR::Type_Bits>()) {
+        const char* key_name_cstr = instanceName.findlast('.');
+        key_name_cstr++;  // eats .
+        instanceName = cstring(key_name_cstr);
+        instanceName = instanceName + "_key";
+        key->name = instanceName;
+        key->bitWidth = type->to<IR::Type_Bits>()->width_bits();
+        key->bitWidthFull = type->to<IR::Type_Bits>()->width_bits();
+    } else if (auto st = type->to<IR::Type_Struct>()) {
+        auto field = st->fields[0];
+        key->name = field->name;
+        key->bitWidth = field->type->to<IR::Type_Bits>()->width_bits();
+        key->bitWidthFull = field->type->to<IR::Type_Bits>()->width_bits();
+    } else {
+        ::error(
+            "invalid key type %1% for MatchValueLookupTable"
+            "only Type_Bits and Type_Struct with singled field allowed",
+            type->toString());
+    }
+    key->isInstanceName = true;
+    key->instanceName = "meta";
+    key->isFieldName = true;
+    key->fieldName = "key";
+    key->matchType = exact;
+    key->startBit = 0;
+    key->index = 0;
+    emvlut->keyList.push_back(key);
+}
+
+void DpdkContextGenerator::UpdateImmediateFields(P4MatchLookupTableInfo* emvlut,
+                                                 const IR::Type* type) {
+    int index = 0;
+    int size = 0;
+    if (type->is<IR::Type_Struct>()) {
+        for (auto f : type->to<IR::Type_Struct>()->fields) {
+            if (f->type->is<IR::Type_Bits>()) {
+                auto param = new ImmediateFields();
+                param->param_name = f->name.name;
+                param->param_handle = index++;
+                param->dest_start = size;
+                auto sz = f->type->to<IR::Type_Bits>()->width_bits();
+                param->dest_width = sz;
+                size += sz >> 3;
+                emvlut->matchAttributes->hardware_blocks.at(0)->immediate_fields.push_back(param);
+            }
+        }
+    }
+}
+
+void DpdkContextGenerator::ProcessMatchValueLookupTable(const IR::Declaration_Instance* d) {
+    cstring ctrl_name = "";
+    auto annotations = d->getAnnotations();
+    if (annotations == nullptr) return;
+
+    auto lut_type = annotations->getSingle(IR::Annotation::matchValueLookupTableAnnotation);
+    if (lut_type == nullptr) return;
+    auto resnameexpr = lut_type->expr.at(0);
+    if (resnameexpr->is<IR::StringLiteral>() == false) return;
+
+    auto resname = resnameexpr->to<IR::StringLiteral>()->value;
+
+    /* validate resource name */
+    if (resname != "mirror_profile") {
+        ::error(
+            "Invalid argument '%1%' for 'mvlt_type' annotation for '%2%'"
+            " it should be '%3%'.",
+            resname, d->externalName(), "mirror_profile");
+        return;
+    }
+
+    auto type = typemap->getType(d);
+    if (type->is<IR::Type_SpecializedCanonical>() == false) return;
+
+    auto exactMVLut = new P4MatchLookupTableInfo();
+    exactMVLut->handle = getNewTableHandle();
+    exactMVLut->ctrlName = ctrl_name;
+    exactMVLut->tblName = d->externalName();
+    for (auto kv : structure->pipelines) {
+        auto control = kv.second->to<IR::P4Control>();
+        cstring tableName = control->name.originalName + "." + d->name.originalName;
+        exactMVLut->targetName = tableName;
+    }
+    exactMVLut->p4Hidden = false;
+    exactMVLut->isP4Hidden = true;
+    if (d->arguments->at(0)->expression->is<IR::Constant>()) {
+        exactMVLut->size = d->arguments->at(0)->expression->to<IR::Constant>()->asInt();
+    } else {
+        exactMVLut->size = 255;
+    }
+    exactMVLut->isSize = true;
+    auto typelist = type->to<IR::Type_SpecializedCanonical>()->arguments;
+    auto type0 = typelist->at(0);
+    if (!type0->is<IR::Type_Bits>() && !type0->is<IR::Type_Struct>()) {
+        ::error(
+            "Invalid key type '%1%' for '%2%' 'Type_Bits' or 'Type_Struct'"
+            "expected.",
+            type0, d->externalName());
+        return;
+    }
+    auto type1 = typelist->at(1);
+    if (resname == "mirror_profile") {
+        if (auto s = type1->to<IR::Type_Struct>()) {
+            if (s->fields.size() != 2)
+                ::error("mirror profile expect exactly two immediate key in %1%.", type1);
+        }
+    }
+    auto hwblk = new LookupHwBlocks();
+    hwblk->resource = resname;
+    hwblk->resource_id = 0;
+    exactMVLut->matchAttributes = new LookupMatchAttributes();
+    exactMVLut->matchAttributes->hardware_blocks.push_back(hwblk);
+    UpdateMatchKeys(exactMVLut, type0, d->externalName());
+    UpdateImmediateFields(exactMVLut, type1);
+    contextLutTables.push_back(exactMVLut);
+}
+
+void DpdkContextGenerator::outputImmediateField(Util::JsonArray* immFields,
+                                                ImmediateFields* immfld) {
+    auto* immField = new Util::JsonObject();
+    immField->emplace("param_name", immfld->param_name);
+    immField->emplace("param_handle", immfld->param_handle);
+    immField->emplace("dest_start", immfld->dest_start);
+    immField->emplace("dest_width", immfld->dest_width);
+    immFields->append(immField);
+}
+
+void DpdkContextGenerator::outputKeys(Util::JsonObject* keyJsonObj,
+                                      std::vector<struct MatchKeyField*>& keylist) {
+    auto* keyJsons = new Util::JsonArray();
+    keyJsonObj->emplace("match_key_fields", keyJsons);
+
+    for (auto keyInfo : keylist) {
+        auto* keyJson = new Util::JsonObject();
+        keyJsons->append(keyJson);
+        keyJson->emplace("name", keyInfo->name);
+        if (keyInfo->isInstanceName) {
+            keyJson->emplace("instance_name", keyInfo->instanceName);
+        }
+        if (keyInfo->isFieldName) {
+            keyJson->emplace("field_name", keyInfo->fieldName);
+        }
+        if (keyInfo->matchType == exact) {
+            keyJson->emplace("match_type", "exact");
+        } else if (keyInfo->matchType == ternary) {
+            keyJson->emplace("match_type", "ternary");
+        } else if (keyInfo->matchType == lpm) {
+            keyJson->emplace("match_type", "lpm");
+        } else if (keyInfo->matchType == range) {
+            keyJson->emplace("match_type", "range");
+        } else if (keyInfo->matchType == selector) {
+            keyJson->emplace("match_type", "selector");
+        }
+        keyJson->emplace("start_bit", keyInfo->startBit);
+        keyJson->emplace("bit_width", keyInfo->bitWidth);
+        keyJson->emplace("bit_width_full", keyInfo->bitWidthFull);
+        keyJson->emplace("index", keyInfo->index);
+        keyJson->emplace("position", keyInfo->position);
+    }
+}
+
+void DpdkContextGenerator::outputLutMatchAttributes(Util::JsonObject* matchJsons,
+                                                    struct P4MatchLookupTableInfo* tblInfo) {
+    auto* matchAttr0 = new Util::JsonObject();
+    auto* matchAttrs = new Util::JsonArray();
+    matchJsons->emplace("match_attributes", matchAttr0);
+    matchAttr0->emplace("stage_tables", matchAttrs);
+    if (tblInfo->matchAttributes != nullptr) {
+        for (auto hwBlock : tblInfo->matchAttributes->hardware_blocks) {
+            auto* matchAttr = new Util::JsonObject();
+            matchAttr->emplace("resource", hwBlock->resource);
+            matchAttr->emplace("resource_id", hwBlock->resource_id);
+            auto* immFields = new Util::JsonArray();
+            matchAttr->emplace("immediate_fields", immFields);
+            for (auto immfld : hwBlock->immediate_fields) {
+                outputImmediateField(immFields, immfld);
+            }
+            matchAttrs->append(matchAttr);
+        }
+    }
+}
+
+void DpdkContextGenerator::outputLutTable(Util::JsonArray* tablesJson) {
+    for (auto tbl : contextLutTables) {
+        auto* tableJson = new Util::JsonObject();
+        tableJson->emplace("table_type", "match_value_lookup_table");
+        tableJson->emplace("handle", tbl->handle);
+        tableJson->emplace("name", tbl->tblName);
+        tableJson->emplace("target_name", tbl->targetName);
+        if (tbl->isSize) {
+            tableJson->emplace("size", tbl->size);
+        }
+        if (tbl->isP4Hidden) {
+            tableJson->emplace("p4_hidden", tbl->p4Hidden);
+        }
+        tablesJson->append(tableJson);
+        outputKeys(tableJson, tbl->keyList);
+        outputLutMatchAttributes(tableJson, tbl);
+    }
+}
+
+// Add match value lookup tables to the context json
+void DpdkContextGenerator::addMatchValueLookupTables(Util::JsonArray* tablesJson) {
+    for (auto tbl : mvlTables) {
+        ProcessMatchValueLookupTable(tbl);
+    }
+    outputLutTable(tablesJson);
+}
+
 const Util::JsonObject* DpdkContextGenerator::genContextJsonObject() {
     auto* json = new Util::JsonObject();
     auto* tablesJson = new Util::JsonArray();
@@ -534,6 +747,8 @@ const Util::JsonObject* DpdkContextGenerator::genContextJsonObject() {
     addMatchTables(tablesJson);
     json->emplace("externs", externsJson);
     addExternInfo(externsJson);
+    addMatchValueLookupTables(tablesJson);
+
     return json;
 }
 

--- a/backends/dpdk/dpdkContext.h
+++ b/backends/dpdk/dpdkContext.h
@@ -121,14 +121,131 @@ struct SelectionTable {
     }
 };
 
+enum TableTypes { MATCH = 0 };
+
+enum MatchType { exact = 0, ternary = 1, lpm = 2, range = 3, selector = 4 };
+
+struct MatchKeyFieldValue {
+    cstring fieldName;
+    cstring value;
+    bool isValue;
+    cstring mask;
+    bool isMask;
+    cstring rangeStart;
+    cstring rangeEnd;
+    bool isRange;
+    unsigned int prefixLength;
+    bool isPrefixLength;
+
+    MatchKeyFieldValue() {
+        fieldName = "";
+        value = "";
+        isValue = false;
+        mask = "";
+        isMask = false;
+        rangeStart = "";
+        rangeEnd = "";
+        isRange = false;
+        prefixLength = 0;
+        isPrefixLength = false;
+    }
+};
+
+struct MatchKeyField {
+    cstring name;
+    bool isInstanceName;
+    cstring instanceName;
+    bool isFieldName;
+    cstring fieldName;
+    MatchType matchType;
+    unsigned int startBit;
+    unsigned int bitWidth;
+    unsigned int bitWidthFull;
+    unsigned int index;
+    unsigned int position;
+    MatchKeyField() {
+        name = "";
+        instanceName = "";
+        isInstanceName = false;
+        fieldName = "";
+        isFieldName = false;
+        matchType = exact;
+        startBit = 0;
+        bitWidth = 0;
+        bitWidthFull = 0;
+        index = 0;
+        position = 0;
+    }
+};
+
+struct ImmediateFields {
+    cstring param_name;
+    int param_handle;
+    int dest_start;
+    int dest_width;
+    ImmediateFields() {
+        param_name = "";
+        param_handle = -1;
+        dest_start = -1;
+        dest_width = 0;
+    }
+};
+
+struct LookupHwBlocks {
+    cstring resource;
+    int resource_id;
+    std::vector<ImmediateFields*> immediate_fields;
+    LookupHwBlocks() {
+        resource = "";
+        resource_id = 0;
+    }
+};
+
+struct LookupMatchAttributes {
+    std::vector<LookupHwBlocks*> hardware_blocks;
+};
+
+/* This structure hold match value lookup table attributes
+ * collected from declarations */
+struct P4MatchLookupTableInfo {
+    TableTypes tableType;
+    unsigned int handle;
+    cstring name;
+    cstring ctrlName;
+    cstring tblName;
+    cstring targetName;
+    unsigned int size;
+    bool isSize;
+    bool p4Hidden;
+    bool isP4Hidden;
+    std::vector<MatchKeyField*> keyList;
+    LookupMatchAttributes* matchAttributes;
+
+    P4MatchLookupTableInfo() {
+        tableType = MATCH;
+        handle = 0;
+        name = "";
+        ctrlName = "";
+        tblName = "";
+        size = 0;
+        isSize = false;
+        p4Hidden = false;
+        isP4Hidden = false;
+        matchAttributes = nullptr;
+    }
+};
 // This pass generates context JSON into user specified file
 class DpdkContextGenerator : public Inspector {
     P4::ReferenceMap* refmap;
+    P4::TypeMap* typemap;
     DpdkProgramStructure* structure;
     DpdkOptions& options;
     // All tables are collected into this vector
     IR::IndexedVector<IR::Declaration> tables;
     std::vector<const IR::Declaration_Instance*> externs;
+    // All match value lookup tables collected into this vector
+    std::vector<const IR::Declaration_Instance*> mvlTables;
+    std::vector<P4MatchLookupTableInfo*> contextLutTables;
 
     // Maps holding table, extern and action attributes needed for context JSON
     std::map<const cstring, struct TableAttributes> tableAttrmap;
@@ -140,9 +257,9 @@ class DpdkContextGenerator : public Inspector {
     static unsigned newActionHandle;
 
  public:
-    DpdkContextGenerator(P4::ReferenceMap* refmap, DpdkProgramStructure* structure,
-                         DpdkOptions& options)
-        : refmap(refmap), structure(structure), options(options) {}
+    DpdkContextGenerator(P4::ReferenceMap* refmap, P4::TypeMap* typemap,
+                         DpdkProgramStructure* structure, DpdkOptions& options)
+        : refmap(refmap), typemap(typemap), structure(structure), options(options) {}
 
     unsigned int getNewTableHandle();
     unsigned int getNewActionHandle();
@@ -151,6 +268,16 @@ class DpdkContextGenerator : public Inspector {
     void addMatchTables(Util::JsonArray* tablesJson);
     void addExternInfo(Util::JsonArray* externsJson);
     Util::JsonObject* initTableCommonJson(const cstring name, const struct TableAttributes& attr);
+    void addMatchValueLookupTables(Util::JsonArray* tablesJson);
+    void UpdateImmediateFields(P4MatchLookupTableInfo* emvlut, const IR::Type* type);
+    void UpdateMatchKeys(P4MatchLookupTableInfo* emvlut, const IR::Type* type,
+                         cstring instanceName);
+    void ProcessMatchValueLookupTable(const IR::Declaration_Instance* d);
+    void outputLutTable(Util::JsonArray* tablesJson);
+    void outputLutMatchAttributes(Util::JsonObject* matchJson,
+                                  struct P4MatchLookupTableInfo* tblInfo);
+    void outputKeys(Util::JsonObject* matchJson, std::vector<struct MatchKeyField*>& keylist);
+    void outputImmediateField(Util::JsonArray* immFieldJson, ImmediateFields* immfld);
     void addKeyField(Util::JsonArray* keyJson, const cstring name, const cstring annon,
                      const IR::KeyElement* key, int position);
     Util::JsonArray* addActions(const IR::P4Table* table, const cstring ctrlName, bool isMatch);

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -1143,6 +1143,8 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement* s) {
                 auto reg = a->object->getName();
                 add_instr(new IR::DpdkRegisterWriteStatement(reg, index, src));
             }
+        } else if (a->originalExternType->getName().name == "MatchValueLookupTable") {
+            // No instructions emitted for MatchValueLookupTable in .spec file.
         } else {
             ::error(ErrorType::ERR_UNKNOWN, "%1%: Unknown extern function.", s);
         }

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -172,6 +172,8 @@ class P4RuntimeArchHandlerPSAPNA : public P4RuntimeArchHandlerCommon<arch> {
         if (decl == nullptr) return;
         if (externBlock->type->name == "Digest") {
             symbols->add(SymbolType::DIGEST(), decl);
+        } else if (externBlock->type->name == MatchValueLookupTableExtern::typeName()) {
+            symbols->add(SymbolType::MATCH_VALUE_LOOKUP_TABLE(), decl->controlPlaneName());
         }
     }
 
@@ -188,16 +190,181 @@ class P4RuntimeArchHandlerPSAPNA : public P4RuntimeArchHandlerCommon<arch> {
         }
     }
 
+    static p4configv1::Extern* getP4InfoExtern(P4RuntimeSymbolType typeId, cstring typeName,
+                                               p4configv1::P4Info* p4info) {
+        for (auto& externType : *p4info->mutable_externs()) {
+            if (externType.extern_type_id() == static_cast<p4rt_id_t>(typeId)) return &externType;
+        }
+        auto* externType = p4info->add_externs();
+        externType->set_extern_type_id(static_cast<p4rt_id_t>(typeId));
+        externType->set_extern_type_name(typeName);
+        return externType;
+    }
+
+    static cstring prefix(cstring p, cstring str) {
+        return p.isNullOrEmpty() ? str : p + "." + str;
+    }
+    void addP4InfoExternInstance(const P4RuntimeSymbolTableIface& symbols,
+                                 P4RuntimeSymbolType typeId, cstring typeName, cstring name,
+                                 const IR::IAnnotated* annotations,
+                                 const ::google::protobuf::Message& message,
+                                 p4configv1::P4Info* p4info, cstring pipeName) {
+        auto* externType = getP4InfoExtern(typeId, typeName, p4info);
+        auto* externInstance = externType->add_instances();
+        auto* pre = externInstance->mutable_preamble();
+        pre->set_id(symbols.getId(typeId, name));
+        pre->set_name(prefix(pipeName, name));
+        pre->set_alias(symbols.getAlias(name));
+        Helpers::addAnnotations(pre, annotations);
+        Helpers::addDocumentation(pre, annotations);
+        externInstance->mutable_info()->PackFrom(message);
+    }
+
+    void addMatchValueLookupTable(const P4RuntimeSymbolTableIface& symbols,
+                                  p4configv1::P4Info* p4Info, const MatchValueLookupTable& mvltbl,
+                                  cstring pipeName = "") {
+        p4configv1::MatchValueLookupTable p4info_mvlut;
+        // set fixed match filed
+        p4configv1::MatchField* match = p4info_mvlut.add_match_fields();
+        match->set_id(1);
+        match->set_name(mvltbl.key_name);
+        match->set_bitwidth(mvltbl.key_bitwidth);
+        match->set_match_type(p4configv1::MatchField_MatchType_EXACT);
+
+        // set values
+        for (auto p : mvltbl.params) {
+            auto param = p4info_mvlut.add_params();
+            param->set_id(p.id);
+            param->set_name(p.name.c_str());
+            param->set_bitwidth(p.bitwidth);
+        }
+
+        // set size field
+        p4info_mvlut.set_size(mvltbl.size);
+
+        // add the MVLUT instance into p4info
+        addP4InfoExternInstance(symbols, SymbolType::MATCH_VALUE_LOOKUP_TABLE(),
+                                MatchValueLookupTableExtern::directTypeName(), mvltbl.name,
+                                mvltbl.annotations, p4info_mvlut, p4Info, pipeName);
+    }
+
+    void add_mvlut_param(uint32_t& param_count, std::vector<mvlut_param_t>* params_list,
+                         const IR::Type* type, cstring decl_name, cstring prefix) {
+        if (type->is<IR::Type_Struct>()) {
+            auto stype = type->to<IR::Type_Struct>();
+            cstring newprefix = prefix != "" ? prefix + "_" + decl_name : decl_name;
+            for (auto field : stype->fields) {
+                add_mvlut_param(param_count, params_list, field->type, field->getName().name,
+                                newprefix);
+            }
+        } else {
+            cstring param_name = prefix == "" ? decl_name : prefix + "_" + decl_name;
+            params_list->emplace_back(
+                mvlut_param_t{param_count++, param_name, (uint32_t)type->width_bits()});
+        }
+    }
+
+    boost::optional<MatchValueLookupTable> getMatchValueLookupTable(
+        const IR::ExternBlock* instance) {
+        auto decl = instance->node->to<IR::Declaration_Instance>();
+        // to be deleted, used to support deprecated ActionSelector constructor.
+        BUG_CHECK(decl->type->is<IR::Type_Specialized>(), "%1%: expected Type_Specialized",
+                  decl->type);
+
+        auto type = decl->type->to<IR::Type_Specialized>();
+        BUG_CHECK(type->arguments->size() == 3, "%1%: expected three type arguments ", decl);
+        cstring inst_name = decl->controlPlaneName();
+        // get key parameter bitwidth
+        uint32_t key_parameter_bitwidth = 0;
+        auto key_type = type->arguments->at(0);
+        cstring key_name;
+        if (auto atype = key_type->to<IR::Type_Bits>()) {
+            cstring key_prefix = inst_name + "_key";
+            // Remove the control block name prefix if exists
+            cstring str_token = key_prefix.findlast('.');
+            if (str_token != nullptr) {
+                key_prefix = str_token.trim(".\t\n\r");
+            }
+            key_name = this->refMap->newName(key_prefix);
+            key_parameter_bitwidth = (uint32_t)atype->width_bits();
+        } else if (key_type->is<IR::Type_Name>()) {
+            auto type_decl =
+                this->refMap->getDeclaration(key_type->to<IR::Type_Name>()->path, true);
+            CHECK_NULL(type_decl);
+            const IR::Type* ty = this->typeMap->getType(type_decl->getNode())->getP4Type();
+            CHECK_NULL(ty);
+            if (ty->is<IR::Type_Struct>()) {
+                auto st_type = ty->to<IR::Type_Struct>();
+                if (st_type->fields.size() != 1) {
+                    ::error(ErrorType::ERR_INVALID,
+                            "%1%: struct type for key shall have only "
+                            "one field in %2%",
+                            key_type, decl);
+                    return boost::none;
+                }
+                auto field_it = st_type->fields.begin();
+                key_name = (*field_it)->name;
+                // assign the unwrapped struct type as key type for later processing
+                key_type = st_type;
+                key_parameter_bitwidth = (uint32_t)key_type->width_bits();
+            }
+        } else {
+            ::error(ErrorType::ERR_INVALID,
+                    "%1%: Invalid key type in %2%. Expected bit "
+                    "type or struct type with one bit type member",
+                    key_type, decl);
+            return boost::none;
+        }
+
+        // get size field value
+        auto size_param = instance->getParameterValue("size");
+        BUG_CHECK(size_param->is<IR::Constant>(),
+                  "Unexpected non constant expression as size argument %1%.", size_param);
+        int val = size_param->to<IR::Constant>()->asInt();
+        if (val < 0) {
+            ::error(ErrorType::ERR_INVALID, "%1%: Invalid value for size argument", size_param);
+            return boost::none;
+        }
+        size_t size_val = (unsigned int)val;
+
+        // create the MVLUT object
+        MatchValueLookupTable tbl(inst_name, key_name, key_parameter_bitwidth, {}, size_val,
+                                  decl->to<IR::IAnnotated>());
+
+        // record the parameter values for MVLUT
+        uint32_t param_count = 1;
+        auto arg_type = type->arguments->at(1);
+        if (auto* type_name = arg_type->to<IR::Type_Name>()) {
+            auto* decl = this->refMap->getDeclaration(type_name->path, true);
+            CHECK_NULL(decl);
+            const IR::Type* type = this->typeMap->getType(decl->getNode());
+            type = type->is<IR::Type_Type>() ? type->to<IR::Type_Type>()->type : type;
+            add_mvlut_param(param_count, &tbl.params, type, "", "");
+        } else if (auto atype = arg_type->to<IR::Type_Bits>()) {
+            add_mvlut_param(param_count, &tbl.params, atype, "", "");
+        } else {
+            ::error(ErrorType::ERR_INVALID,
+                    "%1%: Invalid type for config parameter in %2% "
+                    "instance.",
+                    arg_type, this->EXACT_MVLUT_NAME);
+            return boost::none;
+        }
+
+        return tbl;
+    }
+
     void addExternInstance(const P4RuntimeSymbolTableIface& symbols, p4configv1::P4Info* p4info,
                            const IR::ExternBlock* externBlock) override {
         P4RuntimeArchHandlerCommon<arch>::addExternInstance(symbols, p4info, externBlock);
-
         auto decl = externBlock->node->to<IR::Declaration_Instance>();
         if (decl == nullptr) return;
         auto p4RtTypeInfo = p4info->mutable_type_info();
         if (externBlock->type->name == "Digest") {
             auto digest = getDigest(decl, p4RtTypeInfo);
             if (digest) this->addDigest(symbols, p4info, *digest);
+        } else if (externBlock->type->name == MatchValueLookupTableExtern::typeName()) {
+            auto mvl_table = getMatchValueLookupTable(externBlock);
+            if (mvl_table) addMatchValueLookupTable(symbols, p4info, *mvl_table);
         }
     }
 

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -48,6 +48,8 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
 
         // @match has an expression argument
         PARSE(IR::Annotation::matchAnnotation, Expression),
+        //@match has a string argument
+        PARSE(IR::Annotation::matchValueLookupTableAnnotation, StringLiteral),
     };
 }
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -289,6 +289,7 @@ class Annotation {
     static const cstring noWarnAnnotation;  /// noWarn annotation.
     static const cstring matchAnnotation;  /// Match annotation (for value sets).
     static const cstring fieldListAnnotation;  /// Used for recirculate, etc.
+    static const cstring matchValueLookupTableAnnotation; /// Used for mirror profile
     toString{ return cstring("@") + name; }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -70,6 +70,7 @@ const cstring IR::Annotation::noSideEffectsAnnotation = "noSideEffects";
 const cstring IR::Annotation::noWarnAnnotation = "noWarn";
 const cstring IR::Annotation::matchAnnotation = "match";
 const cstring IR::Annotation::fieldListAnnotation = "field_list";
+const cstring IR::Annotation::matchValueLookupTableAnnotation = "mvlt_type";
 
 int Type_Declaration::nextId = 0;
 int Type_InfInt::nextId = 0;

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -581,6 +581,49 @@ struct pna_main_output_metadata_t {
 // END:Metadata_main_output
 // END:Metadata_types
 
+// BEGIN:MatchValueLookupTable
+extern MatchValueLookupTable<K, V, E> {
+    /**
+     * Create a table with match kinds all 'exact' and the specified
+     * size (number of entries).  The default value returned when a
+     * lookup experiences a miss is given by default_value.
+     */
+    MatchValueLookupTable(int size, V default_value);
+
+    /**
+     * The same as the constructor with an explicit default_value,
+     * except the default_value is the default value for the type V as
+     * defined in the section "Default values" of the P4_16 language
+     * specification.
+     */
+    MatchValueLookupTable(int size);
+
+    /**
+     * Create a table with match kinds all 'exact' and the specified
+     * size (number of entries).  The default value returned when a
+     * lookup experiences a miss is given by default_value.
+     * const_entries is a list of entries, similar to the 'const
+     * entries' table property for tables.
+     *
+     * Example where key and value types are bit<W>:
+     *     MatchValueLookupTable<bit<8>, bit<16>, _>(
+     *         size = 1024,
+     *         const_entries = {
+     *             {5, 10},  // key 5, value 10
+     *             {6, 27},  // key 6, value 27
+     *             {10, 2}   // key 10, value 2
+     *         },
+     *         default_value = 42)  // default value returned for all other keys
+     *     values;
+     */
+    MatchValueLookupTable(int size, V default_value, E const_entries);
+    /**
+     * Look up the key in the table.  Always hits, so always returns a
+     * value of type V.
+     */
+    V lookup(in K key);
+}
+// END:MatchValueLookupTable
 
 // The following extern functions are "forwarding" functions -- they
 // all set the destination of the packet.  Calling one of them


### PR DESCRIPTION
patch needs to applied on p4runtime

```
diff --git a/proto/p4/config/v1/p4info.proto b/proto/p4/config/v1/p4info.proto
index 32869ea..40ccdbf 100644
--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -100,6 +100,7 @@ message P4Ids {
 
     // externs for other architectures (vendor extensions)
     OTHER_EXTERNS_START = 0x80;
+    MATCH_VALUE_LOOKUP_TABLE = 0x83;
 
     // max value for an unsigned 8-bit byte
     MAX = 0xff;
@@ -354,3 +355,16 @@ message Digest {
   Preamble preamble = 1;
   P4DataTypeSpec type_spec = 2;
 }
+
+message Param {
+  uint32 id = 1;
+  string name = 2;
+  uint32 bitwidth = 3;
+}
+
+message MatchValueLookupTable {
+  p4.config.v1.Preamble preamble = 1;
+  repeated p4.config.v1.MatchField match_fields = 2;
+  repeated Param params = 3;
+  uint32 size = 4;
+}
\ No newline at end of file
diff --git a/proto/p4/v1/p4runtime.proto b/proto/p4/v1/p4runtime.proto
index 22c77ce..fa503c8 100755
--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -143,6 +143,26 @@ message ExternEntry {
   .google.protobuf.Any entry = 3;
 }
 
+message ConstEntry {
+  uint32 key = 1;
+  repeated uint32 param_values = 2;
+}
+
+// MatchValueLookupTable
+message MVLUTEntry {
+  uint32 mvlut_id = 1;
+  message ConfigParam {
+    message Param {
+      uint32 param_id = 1;
+      uint64 param_value = 2;
+    }   
+    repeated Param params = 1;
+  }
+  repeated FieldMatch match = 2;
+  ConfigParam param = 3;
+}
+
+
 message TableEntry {
   uint32 table_id = 1;
   repeated FieldMatch match = 2;
```