### PR TITLE
Fix removePipePrefix null handling

### DIFF
--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -24,8 +24,10 @@ namespace P4::DPDK {
 
 cstring DpdkContextGenerator::removePipePrefix(cstring tableName) {
     if (!options.bfRtSchema.empty() || !options.tdiFile.empty()) {
-        cstring tablename = cstring(tableName.find('.'));
-        return tablename.trim(".\t\n\r");
+        if (auto dot = tableName.find('.')) {
+            cstring tablename = cstring(dot);
+            return tablename.trim(".\t\n\r");
+        }
     }
     return tableName;
 }


### PR DESCRIPTION
## Summary
- avoid returning an empty string when a table name has no prefix

## Testing
- `make check-dpdk -j2` *(fails: Error 8)*

------
https://chatgpt.com/codex/tasks/task_e_6871e975dd248330aa3fbfe1ff1b4cce