### PR TITLE
Add parser dump midend pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,7 @@ set (P4C_LIBRARIES controlplane midend frontend ir p4ctoolkit ir-generated)
 
 # The order of adding subdirectories matters because of target dependencies.
 add_subdirectory (tools/driver)
+add_subdirectory (tools/parser_dump)
 add_subdirectory (lib)
 add_subdirectory (tools/ir-generator)
 add_subdirectory (ir)

--- a/backends/bmv2/pna_nic/midend.cpp
+++ b/backends/bmv2/pna_nic/midend.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/convertEnums.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -162,6 +163,9 @@ PnaNicMidEnd::PnaNicMidEnd(CompilerOptions &options, std::ostream *outStream)
             new P4::MidEndLast(),
             evaluator,
             [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
         if (options.listMidendPasses) {
             listPasses(*outStream, cstring::newline);

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/convertEnums.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -169,6 +170,9 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions &options, std::ostream *outStre
             new P4::MidEndLast(),
             evaluator,
             [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
         if (options.listMidendPasses) {
             listPasses(*outStream, cstring::newline);

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/convertEnums.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -138,6 +139,9 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions &options, std::ostream *o
              {options.loopsUnrolling ? new P4::ParsersUnroll(true, &refMap, &typeMap) : nullptr},
              evaluator,
              [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+             options.dumpParserFile.empty()
+                 ? nullptr
+                 : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
              new P4::MidEndLast()});
         if (options.listMidendPasses) {
             listPasses(*outStream, cstring::newline);
@@ -156,6 +160,9 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions &options, std::ostream *o
             [this, fillEnumMap]() { enumMap = fillEnumMap->repr; },
             evaluator,
             [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
     }
 }

--- a/backends/dpdk/midend.cpp
+++ b/backends/dpdk/midend.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include "midend/convertEnums.h"
 #include "midend/convertErrors.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -226,6 +227,9 @@ DpdkMidEnd::DpdkMidEnd(CompilerOptions &options, std::ostream *outStream) {
             new P4::MidEndLast(),
             evaluator,
             new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
         if (options.listMidendPasses) {
             listPasses(*outStream, cstring::newline);
@@ -244,6 +248,9 @@ DpdkMidEnd::DpdkMidEnd(CompilerOptions &options, std::ostream *outStream) {
             new VisitFunctor([this, fillEnumMap]() { enumMap = fillEnumMap->repr; }),
             evaluator,
             new VisitFunctor([this, evaluator]() { toplevel = evaluator->getToplevelBlock(); }),
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
     }
 }

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/convertEnums.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateTuples.h"
@@ -110,6 +111,9 @@ const IR::ToplevelBlock *MidEnd::run(EbpfOptions &options, const IR::P4Program *
              new EBPF::Lower(&refMap, &typeMap),
              new P4::ParsersUnroll(true, &refMap, &typeMap),
              evaluator,
+             options.dumpParserFile.empty()
+                 ? nullptr
+                 : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
              new P4::MidEndLast()});
 
         if (options.arch == "psa") {
@@ -129,7 +133,10 @@ const IR::ToplevelBlock *MidEnd::run(EbpfOptions &options, const IR::P4Program *
         }
     } else {
         midEnd.addPasses({new P4::ResolveReferences(&refMap),
-                          new P4::TypeChecking(&refMap, &typeMap), evaluator});
+                          new P4::TypeChecking(&refMap, &typeMap), evaluator,
+                          options.dumpParserFile.empty()
+                              ? nullptr
+                              : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile)});
     }
     midEnd.setName("MidEnd");
     midEnd.addDebugHooks(hooks);

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/copyStructures.h"
 #include "midend/def_use.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateActionRun.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
@@ -173,6 +174,9 @@ MidEnd::MidEnd(P4TestOptions &options, std::ostream *outStream) {
          options.loopsUnrolling ? new P4::ParsersUnroll(true, &refMap, &typeMap) : nullptr,
          evaluator,
          [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+         options.dumpParserFile.empty()
+             ? nullptr
+             : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
          new P4::FlattenHeaderUnion(&refMap, &typeMap, options.loopsUnrolling),
          new P4::SimplifyControlFlow(&typeMap, true),
          new P4::MidEndLast(),

--- a/backends/tc/midend.cpp
+++ b/backends/tc/midend.cpp
@@ -16,6 +16,8 @@ and limitations under the License.
 
 #include "midend.h"
 
+#include "midend/dumpParserJson.h"
+
 namespace P4::TC {
 
 const IR::ToplevelBlock *MidEnd::run(TCOptions &options, const IR::P4Program *program,
@@ -62,6 +64,9 @@ const IR::ToplevelBlock *MidEnd::run(TCOptions &options, const IR::P4Program *pr
         new EBPF::Lower(&refMap, &typeMap),
         new P4::ParsersUnroll(true, &refMap, &typeMap),
         evaluator,
+        options.dumpParserFile.empty()
+            ? nullptr
+            : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         new P4::MidEndLast(),
     });
     if (options.listMidendPasses) {

--- a/backends/ubpf/midend.cpp
+++ b/backends/ubpf/midend.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/convertEnums.h"
 #include "midend/copyStructures.h"
+#include "midend/dumpParserJson.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateTuples.h"
@@ -105,6 +106,9 @@ const IR::ToplevelBlock *MidEnd::run(EbpfOptions &options, const IR::P4Program *
             new P4::RemoveLeftSlices(&typeMap),
             new EBPF::Lower(&refMap, &typeMap),
             evaluator,
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
             new P4::MidEndLast(),
         });
         if (options.listMidendPasses) {
@@ -120,6 +124,9 @@ const IR::ToplevelBlock *MidEnd::run(EbpfOptions &options, const IR::P4Program *
             new P4::ResolveReferences(&refMap),
             new P4::TypeChecking(&refMap, &typeMap),
             evaluator,
+            options.dumpParserFile.empty()
+                ? nullptr
+                : new P4::DumpParserJson(&refMap, &typeMap, options.dumpParserFile),
         });
     }
     midEnd.setName("MidEnd");

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -60,6 +60,13 @@ CompilerOptions::CompilerOptions(std::string_view defaultMessage) : ParserOption
         },
         "Dump the compiler IR after the midend as JSON in the specified file.");
     registerOption(
+        "--dump-parser", "file",
+        [this](const char *arg) {
+            dumpParserFile = arg;
+            return true;
+        },
+        "Dump parser layout after the midend to the specified JSON file.");
+    registerOption(
         "--ndebug", nullptr,
         [this](const char *) {
             ndebug = true;

--- a/frontends/common/options.h
+++ b/frontends/common/options.h
@@ -57,6 +57,8 @@ class CompilerOptions : public ParserOptions {
     std::vector<cstring> passesToExcludeBackend;
     // Dump a JSON representation of the IR in the file.
     std::filesystem::path dumpJsonFile;
+    // Dump parser layout in the specified file.
+    std::filesystem::path dumpParserFile;
     // Dump and undump the IR tree.
     bool debugJson = false;
     // if this flag is true, compile program in non-debug mode.

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -61,6 +61,7 @@ set (MIDEND_SRCS
   simplifySelectList.cpp
   singleArgumentSelect.cpp
   tableHit.cpp
+  dumpParserJson.cpp
   unrollLoops.cpp
   validateProperties.cpp
   )
@@ -118,12 +119,13 @@ set (MIDEND_HDRS
   simplifySelectList.h
   singleArgumentSelect.h
   tableHit.h
+  dumpParserJson.h
   unrollLoops.h
   validateProperties.h
   )
 
-
 add_library (midend STATIC ${MIDEND_SRCS})
+
 target_link_libraries(midend
   # For TypeMap / RefMap
   PRIVATE frontend

--- a/midend/dumpParserJson.cpp
+++ b/midend/dumpParserJson.cpp
@@ -1,0 +1,178 @@
+#include "midend/dumpParserJson.h"
+
+#include <deque>
+#include <sstream>
+#include <unordered_set>
+
+#include "frontends/p4/evaluator/evaluator.h"
+#include "frontends/p4/methodInstance.h"
+#include "lib/json.h"
+#include "lib/nullstream.h"
+
+namespace P4 {
+
+DumpParserJson::DumpParserJson(const ReferenceMap *refMap, const TypeMap *typeMap,
+                               const std::filesystem::path &file)
+    : refMap(refMap), typeMap(typeMap), file(file) {
+    setName("DumpParserJson");
+}
+
+cstring DumpParserJson::exprName(const IR::Expression *e) {
+    if (auto p = e->to<IR::PathExpression>()) return p->path->name;
+    if (auto m = e->to<IR::Member>()) return exprName(m->expr) + "." + m->member;
+    return e->toString();
+}
+
+int DumpParserJson::fieldOffset(const IR::Type_StructLike *ht, cstring field) {
+    int off = 0;
+    for (auto f : ht->fields) {
+        if (f->name == field) return off;
+        off += f->type->width_bits();
+    }
+    return off;
+}
+
+bool DumpParserJson::preorder(const IR::P4Program *program) {
+    dumpParser(program);
+    return false;
+}
+
+void DumpParserJson::dumpParser(const IR::P4Program *program) const {
+    if (file.empty()) return;
+    const IR::P4Parser *parser = nullptr;
+    for (auto obj : *program) {
+        if (auto p = obj->to<IR::P4Parser>()) {
+            parser = p;
+            break;
+        }
+    }
+    if (!parser) return;
+
+    Util::JsonObject jsonParser;
+    Util::JsonArray *statesArray = new Util::JsonArray();
+    jsonParser.emplace("states", statesArray);
+
+    std::map<cstring, unsigned> headerOffset;
+    unsigned offset = 0;
+
+    // Collect states in execution order starting from start state
+    std::vector<const IR::ParserState *> ordered;
+    std::unordered_set<const IR::ParserState *> visited;
+    std::deque<const IR::ParserState *> work;
+    const auto *startState = parser->getDeclByName(IR::ParserState::start)->to<IR::ParserState>();
+    if (startState) {
+        work.push_back(startState);
+        visited.insert(startState);
+    }
+    while (!work.empty()) {
+        auto st = work.front();
+        work.pop_front();
+        ordered.push_back(st);
+        if (auto sel = st->selectExpression) {
+            if (auto se = sel->to<IR::SelectExpression>()) {
+                for (auto sc : se->selectCases) {
+                    if (auto next = sc->state->getDecl()->to<IR::ParserState>())
+                        if (visited.insert(next).second) work.push_back(next);
+                }
+            } else if (auto pe = sel->to<IR::PathExpression>()) {
+                if (auto next = pe->getDecl()->to<IR::ParserState>())
+                    if (visited.insert(next).second) work.push_back(next);
+            }
+        }
+    }
+    for (auto st : parser->states)
+        if (visited.insert(st).second) ordered.push_back(st);
+
+    std::map<const IR::ParserState *, unsigned> stateId;
+    unsigned sid = 0;
+    for (auto st : ordered) stateId[st] = sid++;
+    jsonParser.emplace("start_state", stateId[startState]);
+
+    for (auto st : ordered) {
+        Util::JsonObject *stateJson = new Util::JsonObject();
+        stateJson->emplace("id", stateId[st]);
+        Util::JsonArray *transitions = new Util::JsonArray();
+        stateJson->emplace("transitions", transitions);
+
+        unsigned width = 0;
+        for (auto comp : st->components) {
+            if (auto mcs = comp->to<IR::MethodCallStatement>()) {
+                auto mi = MethodInstance::resolve(mcs->methodCall, refMap, typeMap);
+                if (auto ext = mi->to<ExternMethod>()) {
+                    if (ext->originalExternType->name == "packet_in" &&
+                        ext->method->name == "extract") {
+                        auto arg = mcs->methodCall->arguments->at(0);
+                        auto htype = typeMap->getType(arg->expression, true)->to<IR::Type_Header>();
+                        if (!htype) continue;
+                        cstring hname = exprName(arg->expression);
+                        if (width == 0) {
+                            auto ex = new Util::JsonObject();
+                            ex->emplace("offset_bits", offset);
+                            stateJson->emplace("extract", ex);
+                        }
+                        headerOffset[hname] = offset + width;
+                        width += htype->width_bits();
+                    }
+                }
+            }
+        }
+        if (width > 0) {
+            auto ex = stateJson->get("extract")->to<Util::JsonObject>();
+            ex->emplace("width_bits", width);
+        }
+        if (st->name == IR::ParserState::accept) stateJson->emplace("accept", true);
+        if (st->name == IR::ParserState::reject) stateJson->emplace("reject", true);
+
+        if (auto sel = st->selectExpression) {
+            if (auto se = sel->to<IR::SelectExpression>()) {
+                for (auto sc : se->selectCases) {
+                    if (sc->keyset->is<IR::DefaultExpression>()) {
+                        stateJson->emplace("default_next_state",
+                                           stateId[sc->state->getDecl()->to<IR::ParserState>()]);
+                        continue;
+                    }
+                    auto mexpr = se->select->components.at(0);
+                    if (auto mem = mexpr->to<IR::Member>()) {
+                        cstring hname = exprName(mem->expr);
+                        unsigned off =
+                            headerOffset[hname] +
+                            fieldOffset(mem->expr->type->to<IR::Type_Header>(), mem->member);
+                        unsigned w = mem->type->width_bits();
+                        big_int val = sc->keyset->to<IR::Constant>()->value;
+                        Util::JsonArray *matchSet = new Util::JsonArray();
+                        Util::JsonObject *m = new Util::JsonObject();
+                        m->emplace("offset_bits", off);
+                        m->emplace("width_bits", w);
+                        std::stringstream ss;
+                        ss << "0x" << std::hex << val;
+                        m->emplace("value", ss.str());
+                        std::stringstream ms;
+                        ms << "0x" << std::hex << ((big_int(1) << w) - 1);
+                        m->emplace("mask", ms.str());
+                        matchSet->append(m);
+                        Util::JsonObject *tr = new Util::JsonObject();
+                        tr->emplace("match_set", matchSet);
+                        tr->emplace("next_state",
+                                    stateId[sc->state->getDecl()->to<IR::ParserState>()]);
+                        transitions->append(tr);
+                    }
+                }
+            } else if (auto pe = sel->to<IR::PathExpression>()) {
+                stateJson->emplace("default_next_state",
+                                   stateId[pe->getDecl()->to<IR::ParserState>()]);
+            }
+        }
+
+        statesArray->append(stateJson);
+        offset += width;
+    }
+
+    Util::JsonObject top;
+    top.emplace("parser", &jsonParser);
+    if (auto out = openFile(file, false)) {
+        jsonParser.serialize(*out);
+        out->flush();
+    }
+}
+
+}  // namespace P4

--- a/midend/dumpParserJson.h
+++ b/midend/dumpParserJson.h
@@ -1,0 +1,31 @@
+#ifndef MIDEND_DUMPPARSERJSON_H_
+#define MIDEND_DUMPPARSERJSON_H_
+
+#include <filesystem>
+
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+#include "ir/visitor.h"
+
+namespace P4 {
+
+class DumpParserJson : public Inspector {
+    const ReferenceMap *refMap;
+    const TypeMap *typeMap;
+    std::filesystem::path file;
+
+ public:
+    DumpParserJson(const ReferenceMap *refMap, const TypeMap *typeMap,
+                   const std::filesystem::path &file);
+
+ private:
+    bool preorder(const IR::P4Program *program) override;
+    static cstring exprName(const IR::Expression *e);
+    static int fieldOffset(const IR::Type_StructLike *ht, cstring field);
+    void dumpParser(const IR::P4Program *program) const;
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_DUMPPARSERJSON_H_ */

--- a/tools/parser_dump/CMakeLists.txt
+++ b/tools/parser_dump/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SRCS parser_dump.cpp)
+add_executable(p4c-dump-parser ${SRCS})
+target_link_libraries(p4c-dump-parser frontend ir-generated ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+install(TARGETS p4c-dump-parser RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})

--- a/tools/parser_dump/parser_dump.cpp
+++ b/tools/parser_dump/parser_dump.cpp
@@ -1,0 +1,186 @@
+#include <deque>
+#include <fstream>
+#include <unordered_set>
+
+#include "frontends/common/options.h"
+#include "frontends/common/parseInput.h"
+#include "frontends/p4/evaluator/evaluator.h"
+#include "frontends/p4/frontend.h"
+#include "frontends/p4/methodInstance.h"
+#include "ir/ir.h"
+#include "lib/json.h"
+#include "lib/log.h"
+#include "lib/nullstream.h"
+
+using namespace P4;
+
+static cstring exprName(const IR::Expression *e) {
+    if (auto p = e->to<IR::PathExpression>()) return p->path->name;
+    if (auto m = e->to<IR::Member>()) return exprName(m->expr) + "." + m->member;
+    return e->toString();
+}
+
+static int fieldOffset(const IR::Type_StructLike *ht, cstring field) {
+    int off = 0;
+    for (auto f : ht->fields) {
+        if (f->name == field) return off;
+        off += f->type->width_bits();
+    }
+    return off;
+}
+
+int main(int argc, char *const argv[]) {
+    CompilerOptions options;
+    options.langVersion = CompilerOptions::FrontendVersion::P4_16;
+    if (options.process(argc, argv) == nullptr) return 1;
+    options.setInputFile();
+
+    AutoCompileContext context(&options);
+    const IR::P4Program *program = parseP4File(options);
+    if (!program || ::P4::errorCount()) return 1;
+
+    FrontEnd fe;
+    program = fe.run(options, program);
+    if (!program || ::P4::errorCount()) return 1;
+
+    ReferenceMap refMap;
+    TypeMap typeMap;
+    EvaluatorPass evaluator(&refMap, &typeMap);
+    program->apply(evaluator);
+
+    const IR::P4Parser *parser = nullptr;
+    for (auto obj : *program) {
+        if (auto p = obj->to<IR::P4Parser>()) {
+            parser = p;
+            break;
+        }
+    }
+    if (parser == nullptr) {
+        ::error("No parser found");
+        return 1;
+    }
+
+    Util::JsonObject jsonParser;
+    Util::JsonArray *statesArray = new Util::JsonArray();
+    jsonParser.emplace("states", statesArray);
+
+    std::map<cstring, unsigned> headerOffset;
+    unsigned offset = 0;
+
+    // Collect states in execution order starting from start state
+    std::vector<const IR::ParserState *> ordered;
+    std::unordered_set<const IR::ParserState *> visited;
+    std::deque<const IR::ParserState *> work;
+    const auto *startState = parser->getDeclByName(IR::ParserState::start)->to<IR::ParserState>();
+    if (startState) {
+        work.push_back(startState);
+        visited.insert(startState);
+    }
+    while (!work.empty()) {
+        auto st = work.front();
+        work.pop_front();
+        ordered.push_back(st);
+        if (auto sel = st->selectExpression) {
+            if (auto se = sel->to<IR::SelectExpression>()) {
+                for (auto sc : se->selectCases) {
+                    if (auto next = sc->state->getDecl()->to<IR::ParserState>())
+                        if (visited.insert(next).second) work.push_back(next);
+                }
+            } else if (auto pe = sel->to<IR::PathExpression>()) {
+                if (auto next = pe->getDecl()->to<IR::ParserState>())
+                    if (visited.insert(next).second) work.push_back(next);
+            }
+        }
+    }
+    for (auto st : parser->states)
+        if (visited.insert(st).second) ordered.push_back(st);
+
+    std::map<const IR::ParserState *, unsigned> stateId;
+    unsigned sid = 0;
+    for (auto st : ordered) stateId[st] = sid++;
+    jsonParser.emplace("start_state", stateId[startState]);
+
+    for (auto st : ordered) {
+        Util::JsonObject *stateJson = new Util::JsonObject();
+        stateJson->emplace("id", stateId[st]);
+        Util::JsonArray *transitions = new Util::JsonArray();
+        stateJson->emplace("transitions", transitions);
+
+        unsigned width = 0;
+        for (auto comp : st->components) {
+            if (auto mcs = comp->to<IR::MethodCallStatement>()) {
+                auto mi = MethodInstance::resolve(mcs->methodCall, &refMap, &typeMap);
+                if (auto ext = mi->to<ExternMethod>()) {
+                    if (ext->originalExternType->name == "packet_in" &&
+                        ext->method->name == "extract") {
+                        auto arg = mcs->methodCall->arguments->at(0);
+                        auto htype = typeMap.getType(arg->expression, true)->to<IR::Type_Header>();
+                        if (!htype) continue;
+                        cstring hname = exprName(arg->expression);
+                        if (width == 0) {
+                            Util::JsonObject *ex = new Util::JsonObject();
+                            ex->emplace("offset_bits", offset);
+                            stateJson->emplace("extract", ex);
+                        }
+                        headerOffset[hname] = offset + width;
+                        width += htype->width_bits();
+                    }
+                }
+            }
+        }
+        if (width > 0) {
+            auto ex = stateJson->get("extract")->to<Util::JsonObject>();
+            ex->emplace("width_bits", width);
+        }
+        if (st->name == IR::ParserState::accept) stateJson->emplace("accept", true);
+        if (st->name == IR::ParserState::reject) stateJson->emplace("reject", true);
+
+        if (auto sel = st->selectExpression) {
+            if (auto se = sel->to<IR::SelectExpression>()) {
+                for (auto sc : se->selectCases) {
+                    if (sc->keyset->is<IR::DefaultExpression>()) {
+                        stateJson->emplace("default_next_state",
+                                           stateId[sc->state->getDecl()->to<IR::ParserState>()]);
+                        continue;
+                    }
+                    auto mexpr = se->select->components.at(0);
+                    if (auto mem = mexpr->to<IR::Member>()) {
+                        cstring hname = exprName(mem->expr);
+                        unsigned off =
+                            headerOffset[hname] +
+                            fieldOffset(mem->expr->type->to<IR::Type_Header>(), mem->member);
+                        unsigned w = mem->type->width_bits();
+                        big_int val = sc->keyset->to<IR::Constant>()->value;
+                        Util::JsonArray *matchSet = new Util::JsonArray();
+                        Util::JsonObject *m = new Util::JsonObject();
+                        m->emplace("offset_bits", off);
+                        m->emplace("width_bits", w);
+                        std::stringstream ss;
+                        ss << "0x" << std::hex << val;
+                        m->emplace("value", ss.str());
+                        std::stringstream ms;
+                        ms << "0x" << std::hex << ((big_int(1) << w) - 1);
+                        m->emplace("mask", ms.str());
+                        matchSet->append(m);
+                        Util::JsonObject *tr = new Util::JsonObject();
+                        tr->emplace("match_set", matchSet);
+                        tr->emplace("next_state",
+                                    stateId[sc->state->getDecl()->to<IR::ParserState>()]);
+                        transitions->append(tr);
+                    }
+                }
+            } else if (auto pe = sel->to<IR::PathExpression>()) {
+                stateJson->emplace("default_next_state",
+                                   stateId[pe->getDecl()->to<IR::ParserState>()]);
+            }
+        }
+
+        statesArray->append(stateJson);
+        offset += width;
+    }
+
+    Util::JsonObject top;
+    top.emplace("parser", &jsonParser);
+    jsonParser.serialize(std::cout);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `DumpParserJson` pass and option `--dump-parser`
- include the pass in main midends
- add new source files to build system
- traverse parser states in execution order when emitting JSON
- fix midend CMake file formatting

## Testing
- `clang-format -i midend/dumpParserJson.cpp tools/parser_dump/parser_dump.cpp`
- `cmake -S . -B build` *(succeeds)*
- `cmake --build build -j $(nproc)` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687f790ad7d0833082c6889f94396a64